### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -20,6 +20,7 @@
     <disclaimer lang="pt">O autor do plugin não tem qualquer relação com o podcast KordKutters nem com a XBMC Foundation</disclaimer>
     <disclaimer lang="pt-br">O autor do plugin não tem qualquer relação com o podcast KordKutters nem com a XBMC Foundation</disclaimer>
     <disclaimer lang="bg">Авторът не е обвързан с KordKutters, както и с XBMC Foundation.</disclaimer>
+    <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <forum>http://forum.kodi.tv/showthread.php?tid=230005</forum>
     <source>https://github.com/enen92/plugin.video.kordkutters</source>
     <website>http://www.kordkutters.com</website>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
